### PR TITLE
fix: migrate deprecated apt_key/apt_repository to deb822_repository and bare ansible_* facts to ansible_facts dict

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,10 @@
 
 # Node.js
 node_modules
+
+.ansible/
+.python-version
+main.py
+pyproject.toml
+uv.lock
+.venv/

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -23,10 +23,10 @@
   become: true
   ansible.builtin.apt:
     update_cache: true
-  when: ansible_pkg_mgr == "apt"
+  when: ansible_facts['pkg_mgr'] == "apt"
 
 - name: "Update dnf cache"
   become: true
   ansible.builtin.dnf:
     update_cache: true
-  when: ansible_pkg_mgr == "dnf"
+  when: ansible_facts['pkg_mgr'] == "dnf"

--- a/tasks/distro-requirements.yml
+++ b/tasks/distro-requirements.yml
@@ -7,13 +7,13 @@
   ansible.builtin.set_fact:
     distro_supported: false
   when: >
-    supported_distros | selectattr("name", "equalto", ansible_distribution) | list | length == 0 or
-    ansible_distribution_version is version(supported_distros | selectattr("name", "equalto", ansible_distribution) | map(attribute="min_version") | first, "<") or
-    ansible_architecture not in (supported_distros | selectattr("name", "equalto", ansible_distribution) | map(attribute="supported_architectures", default=[]) | first)
+    supported_distros | selectattr("name", "equalto", ansible_facts['distribution']) | list | length == 0 or
+    ansible_facts['distribution_version'] is version(supported_distros | selectattr("name", "equalto", ansible_facts['distribution']) | map(attribute="min_version") | first, "<") or
+    ansible_facts['architecture'] not in (supported_distros | selectattr("name", "equalto", ansible_facts['distribution']) | map(attribute="supported_architectures", default=[]) | first)
 
 - name: "Display if distro or architecture is not supported"
   ansible.builtin.debug:
-    msg: "{{ ansible_distribution }} {{ ansible_distribution_version }} on {{ ansible_architecture }} is not supported"
+    msg: "{{ ansible_facts['distribution'] }} {{ ansible_facts['distribution_version'] }} on {{ ansible_facts['architecture'] }} is not supported"
   when: distro_supported is false
 
 # For molecule testing only
@@ -26,5 +26,14 @@
   when: distro_supported is false and "molecule-notest" in ansible_skip_tags
 
 - name: "Skip role if distro or architecture is not supported"
-  ansible.builtin.meta: "{{ netdata_distro_check_fail_state }}"
   when: distro_supported is false
+  block:
+    - name: "End role"
+      ansible.builtin.meta: end_role
+      when: netdata_distro_check_fail_state == "end_role"
+    - name: "End play"
+      ansible.builtin.meta: end_play
+      when: netdata_distro_check_fail_state == "end_play"
+    - name: "End host"
+      ansible.builtin.meta: end_host
+      when: netdata_distro_check_fail_state == "end_host"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -18,7 +18,7 @@
     state: present
     update_cache: true
     cache_valid_time: 3600
-  when: ansible_pkg_mgr == "apt"
+  when: ansible_facts['pkg_mgr'] == "apt"
 
 - name: "Ensure netdata is installed (dnf)"
   ansible.builtin.dnf:
@@ -28,7 +28,7 @@
       - netdata
     state: present
     update_cache: true
-  when: ansible_pkg_mgr == "dnf"
+  when: ansible_facts['pkg_mgr'] == "dnf"
 
 - name: "Ensure netdata is installed (zypper)"
   community.general.zypper:
@@ -36,7 +36,7 @@
       - netdata
     state: present
     update_cache: true
-  when: ansible_pkg_mgr == "zypper"
+  when: ansible_facts['pkg_mgr'] == "zypper"
 
 - name: "Ensure netdata is started"
   ansible.builtin.service:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -32,15 +32,15 @@
 
     - name: "Configure repository (Debian Family)"
       ansible.builtin.include_tasks: repo-Debian.yml
-      when: ansible_os_family == "Debian"
+      when: ansible_facts['os_family'] == "Debian"
 
     - name: "Configure repository (EL Family)"
       ansible.builtin.include_tasks: repo-RedHat.yml
-      when: ansible_os_family == "RedHat"
+      when: ansible_facts['os_family'] == "RedHat"
 
     - name: "Configure repository (Suse)"
       ansible.builtin.include_tasks: repo-Suse.yml
-      when: ansible_os_family == "Suse"
+      when: ansible_facts['os_family'] == "Suse"
 
     - name: "Install"
       ansible.builtin.include_tasks: install.yml

--- a/tasks/remove.yml
+++ b/tasks/remove.yml
@@ -14,13 +14,13 @@
     state: absent
     purge: true
   failed_when: netdata_removal_result.msg is defined and "No package(s) matching 'netdata*' available" in netdata_removal_result.msg
-  when: ansible_pkg_mgr == "apt"
+  when: ansible_facts['pkg_mgr'] == "apt"
 
 - name: "Ensure netdata is removed (openSUSE)"
   community.general.zypper:
     name: netdata
     state: absent
-  when: ansible_pkg_mgr == "zypper"
+  when: ansible_facts['pkg_mgr'] == "zypper"
 
 - name: "Ensure netdata is removed"
   ansible.builtin.package:

--- a/tasks/remove.yml
+++ b/tasks/remove.yml
@@ -26,7 +26,7 @@
   ansible.builtin.package:
     name: netdata*
     state: absent
-  when: ansible_os_family != "Debian" or ansible_os_family != "Suse"
+  when: ansible_facts['os_family'] != "Debian" and ansible_facts['os_family'] != "Suse"
 
 - name: "Remove remaining netdata files"
   ansible.builtin.file:

--- a/tasks/repo-Debian.yml
+++ b/tasks/repo-Debian.yml
@@ -17,24 +17,19 @@
     purge: true
   notify: "Update apt cache"
 
-- name: "Ensure netdata repository is removed (Debian Family) [Legacy]: stable"
-  ansible.builtin.apt_repository:
-    repo: "deb http://repo.netdata.cloud/repos/stable/{{ ansible_distribution | lower }}/ {{ ansible_distribution_release | lower }}/"
+- name: "Ensure legacy netdata repositories are removed (Debian Family) [Legacy]"
+  ansible.builtin.deb822_repository:
+    name: "{{ item }}"
     state: absent
-    filename: netdata-stable
+  loop:
+    - netdata-stable
+    - netdata-edge
   notify: "Update apt cache"
 
-- name: "Ensure netdata repository is removed (Debian Family) [Legacy]: edge"
-  ansible.builtin.apt_repository:
-    repo: "deb http://repo.netdata.cloud/repos/edge}/{{ ansible_distribution | lower }}/ {{ ansible_distribution_release | lower }}/"
+- name: "Ensure legacy netdata GPG key is removed (Debian Family) [Legacy]"
+  ansible.builtin.file:
+    path: /etc/apt/trusted.gpg.d/netdata.asc
     state: absent
-    filename: netdata-edge
-  notify: "Update apt cache"
-
-- name: "Ensure netdata repo key is removed from legacy trusted.gpg keyring (Debian Family) [Legacy]"
-  ansible.builtin.apt_key:
-    state: absent
-    id: 0x6588FDD7B14721FE7C3115E6F9177B5265F56346
   notify: "Update apt cache"
 
 - name: "Ensure netdata-stable.list is removed [Legacy]"

--- a/tasks/repo-Debian.yml
+++ b/tasks/repo-Debian.yml
@@ -61,18 +61,18 @@
     - name: "Ensure netdata repository is configured (Debian Family): {{ netdata_agent_channel }}"
       ansible.builtin.deb822_repository:
         name: netdata-{{ netdata_agent_channel }}
-        uris: "http://repo.netdata.cloud/repos/{{ netdata_agent_channel }}/{{ ansible_distribution | lower }}"
+        uris: "http://repo.netdata.cloud/repos/{{ netdata_agent_channel }}/{{ ansible_facts['distribution'] | lower }}"
         signed_by: "https://repo.netdata.cloud/netdatabot.gpg.key"
-        suites: "{{ ansible_distribution_release | lower }}/"
+        suites: "{{ ansible_facts['distribution_release'] | lower }}/"
         state: present
         enabled: true
 
     - name: "Ensure netdata repository is removed (Debian Family): {{ netdata_agent_channel_remove }}"
       ansible.builtin.deb822_repository:
         name: netdata-{{ netdata_agent_channel_remove }}
-        uris: "http://repo.netdata.cloud/repos/{{ netdata_agent_channel_remove }}/{{ ansible_distribution | lower }}"
+        uris: "http://repo.netdata.cloud/repos/{{ netdata_agent_channel_remove }}/{{ ansible_facts['distribution'] | lower }}"
         signed_by: "https://repo.netdata.cloud/netdatabot.gpg.key"
-        suites: "{{ ansible_distribution_release | lower }}/"
+        suites: "{{ ansible_facts['distribution_release'] | lower }}/"
         state: absent
         enabled: true
       notify: "Remove netdata"
@@ -84,9 +84,9 @@
     - name: "Ensure netdata repository is removed (Debian Family): {{ netdata_agent_channel }}"
       ansible.builtin.deb822_repository:
         name: netdata-{{ netdata_agent_channel }}
-        uris: "http://repo.netdata.cloud/repos/{{ netdata_agent_channel }}/{{ ansible_distribution | lower }}"
+        uris: "http://repo.netdata.cloud/repos/{{ netdata_agent_channel }}/{{ ansible_facts['distribution'] | lower }}"
         signed_by: "https://repo.netdata.cloud/netdatabot.gpg.key"
-        suites: "{{ ansible_distribution_release | lower }}/"
+        suites: "{{ ansible_facts['distribution_release'] | lower }}/"
         state: absent
         enabled: true
 

--- a/tasks/repo-Debian.yml
+++ b/tasks/repo-Debian.yml
@@ -44,15 +44,9 @@
     state: absent
   notify: "Update apt cache"
 
-- name: "Set fact netdata_agent_channel_remove to edge"
+- name: "Determine repository channel to remove (opposite of selected)"
   ansible.builtin.set_fact:
-    netdata_agent_channel_remove: edge
-  when: netdata_agent_channel == "stable"
-
-- name: "Set fact netdata_agent_channel_remove to stable"
-  ansible.builtin.set_fact:
-    netdata_agent_channel_remove: stable
-  when: netdata_agent_channel == "edge"
+    netdata_agent_channel_remove: "{{ 'edge' if netdata_agent_channel == 'stable' else 'stable' }}"
 
 - name: "Add netdata repository"
   when: netdata_agent_state == "present"
@@ -61,6 +55,7 @@
     - name: "Ensure netdata repository is configured (Debian Family): {{ netdata_agent_channel }}"
       ansible.builtin.deb822_repository:
         name: netdata-{{ netdata_agent_channel }}
+        types: [deb]
         uris: "http://repo.netdata.cloud/repos/{{ netdata_agent_channel }}/{{ ansible_facts['distribution'] | lower }}"
         signed_by: "https://repo.netdata.cloud/netdatabot.gpg.key"
         suites: "{{ ansible_facts['distribution_release'] | lower }}/"
@@ -70,6 +65,7 @@
     - name: "Ensure netdata repository is removed (Debian Family): {{ netdata_agent_channel_remove }}"
       ansible.builtin.deb822_repository:
         name: netdata-{{ netdata_agent_channel_remove }}
+        types: [deb]
         uris: "http://repo.netdata.cloud/repos/{{ netdata_agent_channel_remove }}/{{ ansible_facts['distribution'] | lower }}"
         signed_by: "https://repo.netdata.cloud/netdatabot.gpg.key"
         suites: "{{ ansible_facts['distribution_release'] | lower }}/"
@@ -84,6 +80,7 @@
     - name: "Ensure netdata repository is removed (Debian Family): {{ netdata_agent_channel }}"
       ansible.builtin.deb822_repository:
         name: netdata-{{ netdata_agent_channel }}
+        types: [deb]
         uris: "http://repo.netdata.cloud/repos/{{ netdata_agent_channel }}/{{ ansible_facts['distribution'] | lower }}"
         signed_by: "https://repo.netdata.cloud/netdatabot.gpg.key"
         suites: "{{ ansible_facts['distribution_release'] | lower }}/"

--- a/tasks/repo-RedHat.yml
+++ b/tasks/repo-RedHat.yml
@@ -53,15 +53,9 @@
         sslverify: true
 
     # Ensure that either stable or edge repo is removed
-    - name: "Set fact netdata_agent_channel_remove to edge"
+    - name: "Determine repository channel to remove (opposite of selected)"
       ansible.builtin.set_fact:
-        netdata_agent_channel_remove: edge
-      when: netdata_agent_channel == "stable"
-
-    - name: "Set fact netdata_agent_channel_remove to stable"
-      ansible.builtin.set_fact:
-        netdata_agent_channel_remove: stable
-      when: netdata_agent_channel == "edge"
+        netdata_agent_channel_remove: "{{ 'edge' if netdata_agent_channel == 'stable' else 'stable' }}"
 
     - name: "Ensure netdata repository is removed (RedHat Family): {{ netdata_agent_channel_remove }}"
       ansible.builtin.yum_repository:

--- a/tasks/repo-RedHat.yml
+++ b/tasks/repo-RedHat.yml
@@ -6,17 +6,17 @@
 - name: "Set netdata_el_repo_distro (Oracle Linux)"
   ansible.builtin.set_fact:
     netdata_el_repo_distro: ol
-  when: ansible_distribution == "OracleLinux"
+  when: ansible_facts['distribution'] == "OracleLinux"
 
 - name: "Set netdata_el_repo_distro (Fedora)"
   ansible.builtin.set_fact:
     netdata_el_repo_distro: fedora
-  when: ansible_distribution == "Fedora"
+  when: ansible_facts['distribution'] == "Fedora"
 
 - name: "Set netdata_el_repo_distro (Amazon Linux)"
   ansible.builtin.set_fact:
     netdata_el_repo_distro: amazonlinux
-  when: ansible_distribution == "Amazon"
+  when: ansible_facts['distribution'] == "Amazon"
 
 - name: "Ensure netdata-repo is removed (RedHat Family)"
   ansible.builtin.package:
@@ -39,7 +39,7 @@
 
     - name: "Ensure netdata repository is configured (RedHat Family): {{ netdata_agent_channel }}"
       ansible.builtin.yum_repository:
-        baseurl: https://repo.netdata.cloud/repos/{{ netdata_agent_channel }}/{{ netdata_el_repo_distro }}/{{ ansible_distribution_major_version }}/{{ ansible_architecture }}/
+        baseurl: https://repo.netdata.cloud/repos/{{ netdata_agent_channel }}/{{ netdata_el_repo_distro }}/{{ ansible_facts['distribution_major_version'] }}/{{ ansible_facts['architecture'] }}/
         description: Netdata {{ netdata_agent_channel }}
         state: present
         enabled: true
@@ -65,7 +65,7 @@
 
     - name: "Ensure netdata repository is removed (RedHat Family): {{ netdata_agent_channel_remove }}"
       ansible.builtin.yum_repository:
-        baseurl: https://repo.netdata.cloud/repos/{{ netdata_agent_channel_remove }}/{{ netdata_el_repo_distro }}/{{ ansible_distribution_major_version }}/{{ ansible_architecture }}/
+        baseurl: https://repo.netdata.cloud/repos/{{ netdata_agent_channel_remove }}/{{ netdata_el_repo_distro }}/{{ ansible_facts['distribution_major_version'] }}/{{ ansible_facts['architecture'] }}/
         description: Netdata {{ netdata_agent_channel_remove }}
         state: absent
         enabled: true
@@ -86,7 +86,7 @@
   block:
     - name: "Ensure netdata repository is removed (RedHat Family): stable"
       ansible.builtin.yum_repository:
-        baseurl: https://repo.netdata.cloud/repos/stable/{{ netdata_el_repo_distro }}/{{ ansible_distribution_major_version }}/{{ ansible_architecture }}/
+        baseurl: https://repo.netdata.cloud/repos/stable/{{ netdata_el_repo_distro }}/{{ ansible_facts['distribution_major_version'] }}/{{ ansible_facts['architecture'] }}/
         description: Netdata stable
         state: absent
         enabled: true
@@ -101,7 +101,7 @@
 
     - name: "Ensure netdata repository is removed (RedHat Family): edge"
       ansible.builtin.yum_repository:
-        baseurl: https://repo.netdata.cloud/repos/edge/{{ netdata_el_repo_distro }}/{{ ansible_distribution_major_version }}/{{ ansible_architecture }}/
+        baseurl: https://repo.netdata.cloud/repos/edge/{{ netdata_el_repo_distro }}/{{ ansible_facts['distribution_major_version'] }}/{{ ansible_facts['architecture'] }}/
         description: Netdata edge
         state: absent
         enabled: true

--- a/tasks/repo-Suse.yml
+++ b/tasks/repo-Suse.yml
@@ -24,15 +24,9 @@
         priority: 50
 
     # Ensure that either stable or edge repo is removed
-    - name: "Set fact netdata_agent_channel_remove to edge"
+    - name: "Determine repository channel to remove (opposite of selected)"
       ansible.builtin.set_fact:
-        netdata_agent_channel_remove: edge
-      when: netdata_agent_channel == "stable"
-
-    - name: "Set fact netdata_agent_channel_remove to stable"
-      ansible.builtin.set_fact:
-        netdata_agent_channel_remove: stable
-      when: netdata_agent_channel == "edge"
+        netdata_agent_channel_remove: "{{ 'edge' if netdata_agent_channel == 'stable' else 'stable' }}"
 
     - name: "Ensure netdata repository is removed (SUSE): {{ netdata_agent_channel_remove }}"
       community.general.zypper_repository:

--- a/tasks/repo-Suse.yml
+++ b/tasks/repo-Suse.yml
@@ -16,7 +16,7 @@
 
     - name: "Ensure netdata repository is configured (SUSE): {{ netdata_agent_channel }}"
       community.general.zypper_repository:
-        repo: https://repo.netdata.cloud/repos/{{ netdata_agent_channel }}/opensuse/{{ ansible_distribution_version }}/{{ ansible_architecture }}/
+        repo: https://repo.netdata.cloud/repos/{{ netdata_agent_channel }}/opensuse/{{ ansible_facts['distribution_version'] }}/{{ ansible_facts['architecture'] }}/
         description: Netdata {{ netdata_agent_channel }}
         state: present
         enabled: true
@@ -36,7 +36,7 @@
 
     - name: "Ensure netdata repository is removed (SUSE): {{ netdata_agent_channel_remove }}"
       community.general.zypper_repository:
-        repo: https://repo.netdata.cloud/repos/{{ netdata_agent_channel_remove }}/opensuse/{{ ansible_distribution_version }}/{{ ansible_architecture }}/
+        repo: https://repo.netdata.cloud/repos/{{ netdata_agent_channel_remove }}/opensuse/{{ ansible_facts['distribution_version'] }}/{{ ansible_facts['architecture'] }}/
         description: Netdata {{ netdata_agent_channel_remove }}
         state: absent
         enabled: true
@@ -49,7 +49,7 @@
   block:
     - name: "Ensure netdata repository is removed (SUSE): stable"
       community.general.zypper_repository:
-        repo: https://repo.netdata.cloud/repos/stable/opensuse/{{ ansible_distribution_version }}/{{ ansible_architecture }}/
+        repo: https://repo.netdata.cloud/repos/stable/opensuse/{{ ansible_facts['distribution_version'] }}/{{ ansible_facts['architecture'] }}/
         description: Netdata stable
         state: absent
         enabled: true
@@ -58,7 +58,7 @@
 
     - name: "Ensure netdata repository is removed (SUSE): edge"
       community.general.zypper_repository:
-        repo: https://repo.netdata.cloud/repos/edge/opensuse/{{ ansible_distribution_version }}/{{ ansible_architecture }}/
+        repo: https://repo.netdata.cloud/repos/edge/opensuse/{{ ansible_facts['distribution_version'] }}/{{ ansible_facts['architecture'] }}/
         description: Netdata edge
         state: absent
         enabled: true


### PR DESCRIPTION
## Summary

Comprehensive modernization of the role for Ansible 13 (core 2.20). Fixes all `INJECT_FACTS_AS_VARS` deprecation warnings, migrates from deprecated `apt_repository`/`apt_key` modules, and fixes a `meta` action incompatibility.

The `set_fact` simplification and explicit `types: [deb]` additions are inspired by the improvements in [#38](https://github.com/dgibbs64/ansible-role-netdata/pull/38) by @Wayneoween.

## Changes

**`tasks/repo-Debian.yml`** — Replace deprecated apt modules
- Removed `ansible.builtin.apt_repository` (stable + edge cleanup) and `ansible.builtin.apt_key`
- Replaced with single `ansible.builtin.deb822_repository` loop + `ansible.builtin.file` for GPG key
- Added explicit `types: [deb]` to all `deb822_repository` calls (credit: #38)
- Merged duplicate stable/edge `set_fact` tasks into single Jinja expression (credit: #38)
- Migrated `ansible_distribution` → `ansible_facts["distribution"]` and `ansible_distribution_release` → `ansible_facts["distribution_release"]`

**`tasks/distro-requirements.yml`** — Fix meta action for core 2.20
- `meta: "{{ netdata_distro_check_fail_state }}"` blocked in core 2.20
- Replaced with three explicit conditional `meta` tasks: `end_role`, `end_play`, `end_host`
- Migrated `ansible_distribution` etc. to `ansible_facts` dict

**`tasks/main.yml`** — ansible_facts dict syntax
- `ansible_os_family` → `ansible_facts["os_family"]` for Debian/RedHat/Suse conditionals

**`tasks/remove.yml`** — Fact migration + logic bug fix
- Migrated `ansible_os_family` → `ansible_facts["os_family"]`, `ansible_pkg_mgr` → `ansible_facts["pkg_mgr"]`
- Fixed logic bug: `or` → `and` in OS family check

**`tasks/install.yml`, `handlers/main.yml`** — `ansible_pkg_mgr` migration

**`tasks/repo-RedHat.yml`, `tasks/repo-Suse.yml`** — Fact migration + set_fact simplification
- Migrated all bare `ansible_*` facts to `ansible_facts` dict
- Merged duplicate stable/edge `set_fact` tasks (credit: #38)

## Validation

- `ansible-lint` (production profile): **0 failures, 0 warnings**
- `molecule local converge` (ubuntu2204): **34 ok, 0 failed, 0 INJECT_FACTS_AS_VARS warnings**
- Referenced against [Ansible 13 Porting Guide](https://docs.ansible.com/projects/ansible/latest/porting_guides/porting_guide_13.html)
- Zero remaining bare `ansible_*` fact lookups in `tasks/` and `handlers/`