### PR TITLE
fix: resolve ansible-core 2.20 incompatibilities and migrate bare facts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,10 @@
 
 # Node.js
 node_modules
+
+.ansible/
+.python-version
+main.py
+pyproject.toml
+uv.lock
+.venv/

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -23,10 +23,10 @@
   become: true
   ansible.builtin.apt:
     update_cache: true
-  when: ansible_pkg_mgr == "apt"
+  when: ansible_facts['pkg_mgr'] == "apt"
 
 - name: "Update dnf cache"
   become: true
   ansible.builtin.dnf:
     update_cache: true
-  when: ansible_pkg_mgr == "dnf"
+  when: ansible_facts['pkg_mgr'] == "dnf"

--- a/tasks/distro-requirements.yml
+++ b/tasks/distro-requirements.yml
@@ -7,13 +7,13 @@
   ansible.builtin.set_fact:
     distro_supported: false
   when: >
-    supported_distros | selectattr("name", "equalto", ansible_distribution) | list | length == 0 or
-    ansible_distribution_version is version(supported_distros | selectattr("name", "equalto", ansible_distribution) | map(attribute="min_version") | first, "<") or
-    ansible_architecture not in (supported_distros | selectattr("name", "equalto", ansible_distribution) | map(attribute="supported_architectures", default=[]) | first)
+    supported_distros | selectattr("name", "equalto", ansible_facts['distribution']) | list | length == 0 or
+    ansible_facts['distribution_version'] is version(supported_distros | selectattr("name", "equalto", ansible_facts['distribution']) | map(attribute="min_version") | first, "<") or
+    ansible_facts['architecture'] not in (supported_distros | selectattr("name", "equalto", ansible_facts['distribution']) | map(attribute="supported_architectures", default=[]) | first)
 
 - name: "Display if distro or architecture is not supported"
   ansible.builtin.debug:
-    msg: "{{ ansible_distribution }} {{ ansible_distribution_version }} on {{ ansible_architecture }} is not supported"
+    msg: "{{ ansible_facts['distribution'] }} {{ ansible_facts['distribution_version'] }} on {{ ansible_facts['architecture'] }} is not supported"
   when: distro_supported is false
 
 # For molecule testing only
@@ -26,5 +26,14 @@
   when: distro_supported is false and "molecule-notest" in ansible_skip_tags
 
 - name: "Skip role if distro or architecture is not supported"
-  ansible.builtin.meta: "{{ netdata_distro_check_fail_state }}"
   when: distro_supported is false
+  block:
+    - name: "End role"
+      ansible.builtin.meta: end_role
+      when: netdata_distro_check_fail_state == "end_role"
+    - name: "End play"
+      ansible.builtin.meta: end_play
+      when: netdata_distro_check_fail_state == "end_play"
+    - name: "End host"
+      ansible.builtin.meta: end_host
+      when: netdata_distro_check_fail_state == "end_host"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -18,7 +18,7 @@
     state: present
     update_cache: true
     cache_valid_time: 3600
-  when: ansible_pkg_mgr == "apt"
+  when: ansible_facts['pkg_mgr'] == "apt"
 
 - name: "Ensure netdata is installed (dnf)"
   ansible.builtin.dnf:
@@ -28,7 +28,7 @@
       - netdata
     state: present
     update_cache: true
-  when: ansible_pkg_mgr == "dnf"
+  when: ansible_facts['pkg_mgr'] == "dnf"
 
 - name: "Ensure netdata is installed (zypper)"
   community.general.zypper:
@@ -36,7 +36,7 @@
       - netdata
     state: present
     update_cache: true
-  when: ansible_pkg_mgr == "zypper"
+  when: ansible_facts['pkg_mgr'] == "zypper"
 
 - name: "Ensure netdata is started"
   ansible.builtin.service:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -32,15 +32,15 @@
 
     - name: "Configure repository (Debian Family)"
       ansible.builtin.include_tasks: repo-Debian.yml
-      when: ansible_os_family == "Debian"
+      when: ansible_facts['os_family'] == "Debian"
 
     - name: "Configure repository (EL Family)"
       ansible.builtin.include_tasks: repo-RedHat.yml
-      when: ansible_os_family == "RedHat"
+      when: ansible_facts['os_family'] == "RedHat"
 
     - name: "Configure repository (Suse)"
       ansible.builtin.include_tasks: repo-Suse.yml
-      when: ansible_os_family == "Suse"
+      when: ansible_facts['os_family'] == "Suse"
 
     - name: "Install"
       ansible.builtin.include_tasks: install.yml

--- a/tasks/remove.yml
+++ b/tasks/remove.yml
@@ -14,19 +14,19 @@
     state: absent
     purge: true
   failed_when: netdata_removal_result.msg is defined and "No package(s) matching 'netdata*' available" in netdata_removal_result.msg
-  when: ansible_pkg_mgr == "apt"
+  when: ansible_facts['pkg_mgr'] == "apt"
 
 - name: "Ensure netdata is removed (openSUSE)"
   community.general.zypper:
     name: netdata
     state: absent
-  when: ansible_pkg_mgr == "zypper"
+  when: ansible_facts['pkg_mgr'] == "zypper"
 
 - name: "Ensure netdata is removed"
   ansible.builtin.package:
     name: netdata*
     state: absent
-  when: ansible_os_family != "Debian" or ansible_os_family != "Suse"
+  when: ansible_facts['os_family'] != "Debian" and ansible_facts['os_family'] != "Suse"
 
 - name: "Remove remaining netdata files"
   ansible.builtin.file:


### PR DESCRIPTION
## Summary

Resolves two ansible-core 2.20 incompatibilities and migrates bare `ansible_*` facts to `ansible_facts` dict syntax across 6 files in response to the `INJECT_FACTS_AS_VARS` deprecation in the [Ansible 13 Porting Guide](https://docs.ansible.com/projects/ansible/latest/porting_guides/porting_guide_13.html).

## Bug fixes

### `tasks/distro-requirements.yml` — Meta action template blocked in core 2.20

`meta: "{{ netdata_distro_check_fail_state }}"` no longer works because ansible-core 2.20 validates module names before Jinja templating. Replaced with three explicit conditional `meta` tasks (`end_role`, `end_play`, `end_host`).

### `tasks/remove.yml` — Logic bug: `or` should be `and`

`when: ansible_facts["os_family"] != "Debian" or ansible_facts["os_family"] != "Suse"` was always `true`, causing the generic `package` removal to overlap redundantly with Debian-specific `apt` and SUSE-specific `zypper` removers. Fixed to `and`.

## Facts migration

All bare `ansible_*` fact lookups migrated to `ansible_facts` dict:

| Fact | Files |
|---|---|
| `ansible_os_family` → `ansible_facts["os_family"]` | `main.yml`, `remove.yml` |
| `ansible_pkg_mgr` → `ansible_facts["pkg_mgr"]` | `install.yml`, `remove.yml`, `handlers/main.yml` |
| `ansible_distribution` → `ansible_facts["distribution"]` | `distro-requirements.yml` |
| `ansible_distribution_version` → `ansible_facts["distribution_version"]` | `distro-requirements.yml` |
| `ansible_architecture` → `ansible_facts["architecture"]` | `distro-requirements.yml` |

`services` (from `service_facts`) and `ansible_skip_tags` are special variables, not injected facts — left unchanged.

## Housekeeping

- `.gitignore`: Added entries for `uv`/venv/devenv tooling files.

## Validation

- `ansible-lint` (production profile): **0 failures, 0 warnings**
- `molecule local converge` (ubuntu2204): **zero `INJECT_FACTS_AS_VARS` warnings**