### PR TITLE
refactor: modernize repository management across all OS families

### DIFF
--- a/tasks/repo-Debian.yml
+++ b/tasks/repo-Debian.yml
@@ -17,24 +17,19 @@
     purge: true
   notify: "Update apt cache"
 
-- name: "Ensure netdata repository is removed (Debian Family) [Legacy]: stable"
-  ansible.builtin.apt_repository:
-    repo: "deb http://repo.netdata.cloud/repos/stable/{{ ansible_distribution | lower }}/ {{ ansible_distribution_release | lower }}/"
+- name: "Ensure legacy netdata repositories are removed (Debian Family) [Legacy]"
+  ansible.builtin.deb822_repository:
+    name: "{{ item }}"
     state: absent
-    filename: netdata-stable
+  loop:
+    - netdata-stable
+    - netdata-edge
   notify: "Update apt cache"
 
-- name: "Ensure netdata repository is removed (Debian Family) [Legacy]: edge"
-  ansible.builtin.apt_repository:
-    repo: "deb http://repo.netdata.cloud/repos/edge}/{{ ansible_distribution | lower }}/ {{ ansible_distribution_release | lower }}/"
+- name: "Ensure legacy netdata GPG key is removed (Debian Family) [Legacy]"
+  ansible.builtin.file:
+    path: /etc/apt/trusted.gpg.d/netdata.asc
     state: absent
-    filename: netdata-edge
-  notify: "Update apt cache"
-
-- name: "Ensure netdata repo key is removed from legacy trusted.gpg keyring (Debian Family) [Legacy]"
-  ansible.builtin.apt_key:
-    state: absent
-    id: 0x6588FDD7B14721FE7C3115E6F9177B5265F56346
   notify: "Update apt cache"
 
 - name: "Ensure netdata-stable.list is removed [Legacy]"
@@ -49,15 +44,9 @@
     state: absent
   notify: "Update apt cache"
 
-- name: "Set fact netdata_agent_channel_remove to edge"
+- name: "Determine repository channel to remove (opposite of selected)"
   ansible.builtin.set_fact:
-    netdata_agent_channel_remove: edge
-  when: netdata_agent_channel == "stable"
-
-- name: "Set fact netdata_agent_channel_remove to stable"
-  ansible.builtin.set_fact:
-    netdata_agent_channel_remove: stable
-  when: netdata_agent_channel == "edge"
+    netdata_agent_channel_remove: "{{ 'edge' if netdata_agent_channel == 'stable' else 'stable' }}"
 
 - name: "Add netdata repository"
   when: netdata_agent_state == "present"
@@ -66,18 +55,20 @@
     - name: "Ensure netdata repository is configured (Debian Family): {{ netdata_agent_channel }}"
       ansible.builtin.deb822_repository:
         name: netdata-{{ netdata_agent_channel }}
-        uris: "http://repo.netdata.cloud/repos/{{ netdata_agent_channel }}/{{ ansible_distribution | lower }}"
+        types: [deb]
+        uris: "http://repo.netdata.cloud/repos/{{ netdata_agent_channel }}/{{ ansible_facts['distribution'] | lower }}"
         signed_by: "https://repo.netdata.cloud/netdatabot.gpg.key"
-        suites: "{{ ansible_distribution_release | lower }}/"
+        suites: "{{ ansible_facts['distribution_release'] | lower }}/"
         state: present
         enabled: true
 
     - name: "Ensure netdata repository is removed (Debian Family): {{ netdata_agent_channel_remove }}"
       ansible.builtin.deb822_repository:
         name: netdata-{{ netdata_agent_channel_remove }}
-        uris: "http://repo.netdata.cloud/repos/{{ netdata_agent_channel_remove }}/{{ ansible_distribution | lower }}"
+        types: [deb]
+        uris: "http://repo.netdata.cloud/repos/{{ netdata_agent_channel_remove }}/{{ ansible_facts['distribution'] | lower }}"
         signed_by: "https://repo.netdata.cloud/netdatabot.gpg.key"
-        suites: "{{ ansible_distribution_release | lower }}/"
+        suites: "{{ ansible_facts['distribution_release'] | lower }}/"
         state: absent
         enabled: true
       notify: "Remove netdata"
@@ -89,9 +80,10 @@
     - name: "Ensure netdata repository is removed (Debian Family): {{ netdata_agent_channel }}"
       ansible.builtin.deb822_repository:
         name: netdata-{{ netdata_agent_channel }}
-        uris: "http://repo.netdata.cloud/repos/{{ netdata_agent_channel }}/{{ ansible_distribution | lower }}"
+        types: [deb]
+        uris: "http://repo.netdata.cloud/repos/{{ netdata_agent_channel }}/{{ ansible_facts['distribution'] | lower }}"
         signed_by: "https://repo.netdata.cloud/netdatabot.gpg.key"
-        suites: "{{ ansible_distribution_release | lower }}/"
+        suites: "{{ ansible_facts['distribution_release'] | lower }}/"
         state: absent
         enabled: true
 

--- a/tasks/repo-RedHat.yml
+++ b/tasks/repo-RedHat.yml
@@ -6,17 +6,17 @@
 - name: "Set netdata_el_repo_distro (Oracle Linux)"
   ansible.builtin.set_fact:
     netdata_el_repo_distro: ol
-  when: ansible_distribution == "OracleLinux"
+  when: ansible_facts['distribution'] == "OracleLinux"
 
 - name: "Set netdata_el_repo_distro (Fedora)"
   ansible.builtin.set_fact:
     netdata_el_repo_distro: fedora
-  when: ansible_distribution == "Fedora"
+  when: ansible_facts['distribution'] == "Fedora"
 
 - name: "Set netdata_el_repo_distro (Amazon Linux)"
   ansible.builtin.set_fact:
     netdata_el_repo_distro: amazonlinux
-  when: ansible_distribution == "Amazon"
+  when: ansible_facts['distribution'] == "Amazon"
 
 - name: "Ensure netdata-repo is removed (RedHat Family)"
   ansible.builtin.package:
@@ -39,7 +39,7 @@
 
     - name: "Ensure netdata repository is configured (RedHat Family): {{ netdata_agent_channel }}"
       ansible.builtin.yum_repository:
-        baseurl: https://repo.netdata.cloud/repos/{{ netdata_agent_channel }}/{{ netdata_el_repo_distro }}/{{ ansible_distribution_major_version }}/{{ ansible_architecture }}/
+        baseurl: https://repo.netdata.cloud/repos/{{ netdata_agent_channel }}/{{ netdata_el_repo_distro }}/{{ ansible_facts['distribution_major_version'] }}/{{ ansible_facts['architecture'] }}/
         description: Netdata {{ netdata_agent_channel }}
         state: present
         enabled: true
@@ -53,19 +53,13 @@
         sslverify: true
 
     # Ensure that either stable or edge repo is removed
-    - name: "Set fact netdata_agent_channel_remove to edge"
+    - name: "Determine repository channel to remove (opposite of selected)"
       ansible.builtin.set_fact:
-        netdata_agent_channel_remove: edge
-      when: netdata_agent_channel == "stable"
-
-    - name: "Set fact netdata_agent_channel_remove to stable"
-      ansible.builtin.set_fact:
-        netdata_agent_channel_remove: stable
-      when: netdata_agent_channel == "edge"
+        netdata_agent_channel_remove: "{{ 'edge' if netdata_agent_channel == 'stable' else 'stable' }}"
 
     - name: "Ensure netdata repository is removed (RedHat Family): {{ netdata_agent_channel_remove }}"
       ansible.builtin.yum_repository:
-        baseurl: https://repo.netdata.cloud/repos/{{ netdata_agent_channel_remove }}/{{ netdata_el_repo_distro }}/{{ ansible_distribution_major_version }}/{{ ansible_architecture }}/
+        baseurl: https://repo.netdata.cloud/repos/{{ netdata_agent_channel_remove }}/{{ netdata_el_repo_distro }}/{{ ansible_facts['distribution_major_version'] }}/{{ ansible_facts['architecture'] }}/
         description: Netdata {{ netdata_agent_channel_remove }}
         state: absent
         enabled: true
@@ -86,7 +80,7 @@
   block:
     - name: "Ensure netdata repository is removed (RedHat Family): stable"
       ansible.builtin.yum_repository:
-        baseurl: https://repo.netdata.cloud/repos/stable/{{ netdata_el_repo_distro }}/{{ ansible_distribution_major_version }}/{{ ansible_architecture }}/
+        baseurl: https://repo.netdata.cloud/repos/stable/{{ netdata_el_repo_distro }}/{{ ansible_facts['distribution_major_version'] }}/{{ ansible_facts['architecture'] }}/
         description: Netdata stable
         state: absent
         enabled: true
@@ -101,7 +95,7 @@
 
     - name: "Ensure netdata repository is removed (RedHat Family): edge"
       ansible.builtin.yum_repository:
-        baseurl: https://repo.netdata.cloud/repos/edge/{{ netdata_el_repo_distro }}/{{ ansible_distribution_major_version }}/{{ ansible_architecture }}/
+        baseurl: https://repo.netdata.cloud/repos/edge/{{ netdata_el_repo_distro }}/{{ ansible_facts['distribution_major_version'] }}/{{ ansible_facts['architecture'] }}/
         description: Netdata edge
         state: absent
         enabled: true

--- a/tasks/repo-Suse.yml
+++ b/tasks/repo-Suse.yml
@@ -16,7 +16,7 @@
 
     - name: "Ensure netdata repository is configured (SUSE): {{ netdata_agent_channel }}"
       community.general.zypper_repository:
-        repo: https://repo.netdata.cloud/repos/{{ netdata_agent_channel }}/opensuse/{{ ansible_distribution_version }}/{{ ansible_architecture }}/
+        repo: https://repo.netdata.cloud/repos/{{ netdata_agent_channel }}/opensuse/{{ ansible_facts['distribution_version'] }}/{{ ansible_facts['architecture'] }}/
         description: Netdata {{ netdata_agent_channel }}
         state: present
         enabled: true
@@ -24,19 +24,13 @@
         priority: 50
 
     # Ensure that either stable or edge repo is removed
-    - name: "Set fact netdata_agent_channel_remove to edge"
+    - name: "Determine repository channel to remove (opposite of selected)"
       ansible.builtin.set_fact:
-        netdata_agent_channel_remove: edge
-      when: netdata_agent_channel == "stable"
-
-    - name: "Set fact netdata_agent_channel_remove to stable"
-      ansible.builtin.set_fact:
-        netdata_agent_channel_remove: stable
-      when: netdata_agent_channel == "edge"
+        netdata_agent_channel_remove: "{{ 'edge' if netdata_agent_channel == 'stable' else 'stable' }}"
 
     - name: "Ensure netdata repository is removed (SUSE): {{ netdata_agent_channel_remove }}"
       community.general.zypper_repository:
-        repo: https://repo.netdata.cloud/repos/{{ netdata_agent_channel_remove }}/opensuse/{{ ansible_distribution_version }}/{{ ansible_architecture }}/
+        repo: https://repo.netdata.cloud/repos/{{ netdata_agent_channel_remove }}/opensuse/{{ ansible_facts['distribution_version'] }}/{{ ansible_facts['architecture'] }}/
         description: Netdata {{ netdata_agent_channel_remove }}
         state: absent
         enabled: true
@@ -49,7 +43,7 @@
   block:
     - name: "Ensure netdata repository is removed (SUSE): stable"
       community.general.zypper_repository:
-        repo: https://repo.netdata.cloud/repos/stable/opensuse/{{ ansible_distribution_version }}/{{ ansible_architecture }}/
+        repo: https://repo.netdata.cloud/repos/stable/opensuse/{{ ansible_facts['distribution_version'] }}/{{ ansible_facts['architecture'] }}/
         description: Netdata stable
         state: absent
         enabled: true
@@ -58,7 +52,7 @@
 
     - name: "Ensure netdata repository is removed (SUSE): edge"
       community.general.zypper_repository:
-        repo: https://repo.netdata.cloud/repos/edge/opensuse/{{ ansible_distribution_version }}/{{ ansible_architecture }}/
+        repo: https://repo.netdata.cloud/repos/edge/opensuse/{{ ansible_facts['distribution_version'] }}/{{ ansible_facts['architecture'] }}/
         description: Netdata edge
         state: absent
         enabled: true


### PR DESCRIPTION
## Summary

Replaces deprecated `ansible.builtin.apt_repository` and `ansible.builtin.apt_key` with modern `ansible.builtin.deb822_repository` and `ansible.builtin.file` on Debian-family systems. Adds explicit repository types and simplifies duplicate `set_fact` channel selection tasks across all three OS families.

The `set_fact` simplification and `types: [deb]` additions are inspired by the improvements in [#38](https://github.com/dgibbs64/ansible-role-netdata/pull/38) by @Wayneoween.

## Changes

### `tasks/repo-Debian.yml`

- **Remove deprecated `apt_repository`** (stable + edge legacy cleanup) — replaced with single `deb822_repository` loop iterating `[netdata-stable, netdata-edge]`
- **Remove deprecated `apt_key`** — replaced with `ansible.builtin.file` removing `/etc/apt/trusted.gpg.d/netdata.asc`
- **Add `types: [deb]`** to all three `deb822_repository` calls for explicitness (credit: #38)
- **Merge duplicate `set_fact`** tasks into single Jinja expression: `"{{ edge if netdata_agent_channel == stable else stable }}"` (credit: #38)
- **Migrate facts**: `ansible_distribution` → `ansible_facts["distribution"]`, `ansible_distribution_release` → `ansible_facts["distribution_release"]`
- Preserved: legacy `.list` file removal tasks and `netdata-repo`/`netdata-repo-edge` package purging

### `tasks/repo-RedHat.yml`

- **Merge duplicate `set_fact`** tasks into single Jinja expression (credit: #38)
- **Migrate facts**: `ansible_distribution` → `ansible_facts["distribution"]`, `ansible_distribution_major_version` → `ansible_facts["distribution_major_version"]`, `ansible_architecture` → `ansible_facts["architecture"]`

### `tasks/repo-Suse.yml`

- **Merge duplicate `set_fact`** tasks into single Jinja expression (credit: #38)
- **Migrate facts**: `ansible_distribution_version` → `ansible_facts["distribution_version"]`, `ansible_architecture` → `ansible_facts["architecture"]`

## Backward compatibility

- `deb822_repository` requires `python3-debian` which is already installed at the top of `repo-Debian.yml`
- All supported distros (Debian 12+, Ubuntu 20.04+, per `meta/main.yml`) ship `python3-debian`
- `ansible_facts` dict syntax resolves identically to bare variable in all versions (min 2.18)

## Validation

- `ansible-lint` (production profile): **0 failures, 0 warnings**
- `molecule local converge` (ubuntu2204): `deb822_repository` tasks run correctly with zero module deprecation warnings